### PR TITLE
Get signed url

### DIFF
--- a/config/cloudflare-stream.php
+++ b/config/cloudflare-stream.php
@@ -66,6 +66,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Base Delivery URL
+    |--------------------------------------------------------------------------
+    | This is the cloudflare Base delivery URL used when self-signing tokens
+    |
+    */
+    'base_delivery_url' => env('CLOUDFLARE_BASE_DELIVERY_URL', 'https://customer-<customer_id>.cloudflarestream.com'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Options
     |--------------------------------------------------------------------------
     | This is the default options that will be applied to all upload

--- a/src/CloudflareStream.php
+++ b/src/CloudflareStream.php
@@ -67,6 +67,11 @@ class CloudflareStream
     private string $baseUrl;
 
     /**
+     * @var string
+     */
+    private string $baseDeliveryUrl;
+
+    /**
      * @var object
      */
     private object $http;
@@ -79,6 +84,9 @@ class CloudflareStream
         $this->setApiToken();
         $this->setAccountId();
         $this->setBaseUrl();
+        $this->setBaseDeliveryUrl();
+        $this->setKeyId();
+        $this->setPem();
         $this->setDefaultOptions();
         $this->setHttpOptions();
     }
@@ -349,5 +357,57 @@ class CloudflareStream
     private function setPem(): void
     {
         $this->pem = config('cloudflare-stream.pem');
+    }
+
+    /**
+     * Set base delivery URL
+     *
+     * @return void
+     */
+    private function setBaseDeliveryUrl(): void
+    {
+        $this->baseDeliveryUrl = config('cloudflare-stream.base_delivery_url');
+    }
+
+    /**
+     * Get the signed url for playback
+     *
+     * @param string $id
+     * @param int $expiresIn
+     * @return array
+     */
+    public function getSignedUrl(string $id, int $expiresIn = 3600)
+    {
+        $token =  $this->signToken($id, $expiresIn);
+        return [
+            'hls' => "$this->baseDeliveryUrl/$token/manifest/video.m3u8",
+            'dash' => "$this->baseDeliveryUrl/$token/manifest/video.mpd"
+        ];
+    }
+
+    private function signToken(string $uid, string $exp = null)
+    {
+        $privateKey = base64_decode($this->pem);
+
+        $header = ['alg' => 'RS256', 'kid' => $this->keyId];
+        $payload = ['sub' => $uid, 'kid' => $this->keyId];
+
+        if ($exp) {
+            $payload['exp'] = time() + $exp;
+        }
+
+        $encodedHeader = self::base64Url(json_encode($header));
+        $encodedPayload = self::base64Url(json_encode($payload));
+
+        openssl_sign("$encodedHeader.$encodedPayload", $signature, $privateKey, 'RSA-SHA256');
+
+        $encodedSignature = self::base64Url($signature);
+
+        return "$encodedHeader.$encodedPayload.$encodedSignature";
+    }
+
+    private function base64Url(string $data)
+    {
+        return str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($data));
     }
 }


### PR DESCRIPTION
Instead of using the Cloudflare's /token endpoint to get a signed playback url, we can create the token ourselves by using the new function `getSignedUrl()`

The function returns an array with `hls` and `dash` signed url's.

In `.env` define variable called `CLOUDFLARE_BASE_DELIVERY_URL` which is the delivery url used when creating the signed urls. For example `https://customer-<customer_id>.cloudflarestream.com`