### PR TITLE
chore(laravel): add support for versions 12 and 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,22 +4,54 @@ on:
   push:
     branches:
       - '*'
+  pull_request:
 
 jobs:
   test:
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.1'
+            laravel: '^10.0'
+            testbench: '^8.0'
+            phpunit: '^10.5'
+          - php: '8.2'
+            laravel: '^11.0'
+            testbench: '^9.0'
+            phpunit: '^11.5'
+          - php: '8.2'
+            laravel: '^12.0'
+            testbench: '^10.0'
+            phpunit: '^11.5'
+          - php: '8.3'
+            laravel: '^13.0'
+            testbench: '^11.0'
+            phpunit: '^12.5'
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Resolve Laravel runtime dependency
+        run: composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
+
+      - name: Resolve Laravel test dependencies
+        run: composer require --dev "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: composer update --no-interaction --prefer-dist --with-all-dependencies
 
       - name: Run PHPUnit Feature tests
         run: ./vendor/bin/phpunit --testsuite Feature

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 A Laravel Package for working with Cloudflare Stream seamlessly
 
+Supports Laravel 10, 11, 12, and 13.
+
 ## Installation
 
 Run
@@ -40,7 +42,7 @@ Open your .env file and add the following variables, remember to substitute the 
 ```php
 CLOUDFLARE_API_TOKEN=xxxxxxxxxxxx
 CLOUDFLARE_ACCOUNT_ID=xxxxxxxxxxxxxxxxx
-CLOUDFLARE_BASE_API_URL=https://api.cloudflare.com/client/v4/accounts
+CLOUDFLARE_API_BASE_URL=https://api.cloudflare.com/client/v4/accounts
 CLOUDFLARE_KEY_ID=xxxxxxxxxxxxxxx
 ```
 
@@ -60,7 +62,7 @@ class StreamService
     
     public function fetchVideo(string $id): array
     {
-       return CloudflareStreamFacade::fetchVideo(string $id)
+        return CloudflareStreamFacade::fetchVideo($id);
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,9 @@
         "laravel",
         "Open Source",
         "stream",
-        "videos",
-        "Laravel 10"
+        "videos"
     ],
     "license": "MIT",
-    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "Bjthecod3r\\CloudflareStream\\": "src/"
@@ -32,7 +30,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0 || ^11.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0 || ^13.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "extra": {
@@ -46,9 +44,9 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0.0",
-        "mockery/mockery": "^1.3.0",
-        "orchestra/testbench": "^8.0"
+        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.0 || ^13.0",
+        "mockery/mockery": "^1.6.10",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
     "scripts": {
         "post-autoload-dump": [


### PR DESCRIPTION
## Summary
- expand package constraints to support Laravel 10, 11, 12, and 13
- add a GitHub Actions matrix to test the supported Laravel and PHP combinations
- refresh the README support note and fix the configuration/example typos

## Testing
- composer validate --strict
- ./vendor/bin/phpunit --testsuite Feature

## Risks
- CI now resolves framework-specific dependency sets per matrix job, so workflow runtime will be higher than the previous single-version install